### PR TITLE
Fix numeric sorting of model parts before joining

### DIFF
--- a/download_multi_part.sh
+++ b/download_multi_part.sh
@@ -73,7 +73,9 @@ done
 
 # --- 5. Join All Parts ---
 # Sort the parts numerically to ensure correct order before joining
-IFS=$'\n' SORTED_PARTS=($(sort <<<"${DOWNLOADED_PARTS[*]}"))
+IFS=$'\n' mapfile -t SORTED_PARTS < <(
+  printf '%s\n' "${DOWNLOADED_PARTS[@]}" | sort -t '_' -k2,2n
+)
 unset IFS
 
 echo


### PR DESCRIPTION
## Summary
- Ensure `download_multi_part.sh` sorts part files numerically before joining
- Use `mapfile` and numeric `sort` to handle double-digit part numbers correctly

## Testing
- `shellcheck download_multi_part.sh`
- `DOWNLOADED_PARTS=(part_1.tmp part_2.tmp part_10.tmp); IFS=$'\n' mapfile -t SORTED_PARTS < <(printf '%s\n' "${DOWNLOADED_PARTS[@]}" | sort -t '_' -k2,2n); unset IFS; echo "sorted: ${SORTED_PARTS[*]}"`

------
https://chatgpt.com/codex/tasks/task_e_68af41cd89748322a8977abc14e7879a