### PR TITLE
chore: remove runpod helper library

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -142,12 +142,6 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked --mount=type=cache,t
     && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1 \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# --- Install pip and the RunPod helper library for SSH functionality ---
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked --mount=type=cache,target=/var/lib/apt,sharing=locked \
-    apt-get update && apt-get install -y --no-install-recommends python3-pip && \
-    apt-get clean && rm -rf /var/lib/apt/lists/*
-RUN --mount=type=cache,target=/root/.cache/pip pip3 install runpod
-
 # --- 2. Copy ALL Built Assets from the 'builder' Stage ---
 COPY --from=builder /opt/venv-webui /opt/venv-webui
 COPY --from=builder /opt/venv-comfyui /opt/venv-comfyui

--- a/start_textgenui.sh
+++ b/start_textgenui.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
-# SCRIPT V7 - Remove unsupported Gradio upload directory option
+# SCRIPT V8 - Link persistent user data and remove unsupported Gradio upload directory option
 
 cd /opt/text-generation-webui || exit
+# Link persistent user data for uploads and cache
+mkdir -p "${TEXTGEN_DATA_DIR}"
+ln -sfn "${TEXTGEN_DATA_DIR}" user_data
 
 # --- 1. Build Argument Array ---
 CMD_ARGS=()

--- a/start_textgenui.sh
+++ b/start_textgenui.sh
@@ -1,18 +1,13 @@
 #!/bin/bash
-# SCRIPT V6 - Added persistent upload directory and optional extension.
+# SCRIPT V7 - Remove unsupported Gradio upload directory option
 
 cd /opt/text-generation-webui || exit
-
-# Create persistent upload directory
-UPLOAD_DIR="${TEXTGEN_DATA_DIR}/uploads"
-mkdir -p "$UPLOAD_DIR"
 
 # --- 1. Build Argument Array ---
 CMD_ARGS=()
 
 # --- 2. Networking and Base Flags ---
 CMD_ARGS+=(--listen --listen-host 0.0.0.0 --listen-port 7860 --api)
-CMD_ARGS+=(--gradio-upload-dir "$UPLOAD_DIR")
 
 # --- 3. Optional Extensions ---
 if [ -d "extensions/LLM_Web_search" ]; then


### PR DESCRIPTION
## Summary
- drop runpod helper library from final Docker image
- rely on standard RunPod CLI for SSH access

## Testing
- `hadolint Dockerfile` *(fails: command not found)*
- `docker build -q .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b050ad8a708322b422d79c04b175da