### PR TITLE
chore: remove runpod helper library and persist comfyui deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -108,6 +108,10 @@ RUN cd /opt/ComfyUI/custom_nodes && \
     cd ComfyUI-Manager && \
     /opt/venv-comfyui/bin/python3 -m pip install --no-cache-dir -r requirements.txt
 
+# Pre-install dependencies for common community node packs
+RUN --mount=type=cache,target=/root/.cache/pip \
+    /opt/venv-comfyui/bin/python3 -m pip install --no-cache-dir ultralytics piexif
+
 # --- 8. Remove VCS metadata to trim image ---
 RUN rm -rf /app/.git /opt/ComfyUI/.git /opt/text-generation-webui/.git
 
@@ -141,12 +145,6 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked --mount=type=cache,t
     curl supervisor ffmpeg libgomp1 python3.11 nano aria2 rsync git git-lfs iproute2 \
     && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1 \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
-
-# --- Install pip and the RunPod helper library for SSH functionality ---
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked --mount=type=cache,target=/var/lib/apt,sharing=locked \
-    apt-get update && apt-get install -y --no-install-recommends python3-pip && \
-    apt-get clean && rm -rf /var/lib/apt/lists/*
-RUN --mount=type=cache,target=/root/.cache/pip pip3 install runpod
 
 # --- 2. Copy ALL Built Assets from the 'builder' Stage ---
 COPY --from=builder /opt/venv-webui /opt/venv-webui

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,6 +18,18 @@ mkdir -p "${OPENWEBUI_DATA_DIR}"
 mkdir -p "${TEXTGEN_DATA_DIR}"
 mkdir -p "/workspace/temp_gguf"
 
+# --- Persist ComfyUI virtual environment to workspace ---
+COMFYUI_VENV_PATH="/opt/venv-comfyui"
+COMFYUI_VENV_PERSIST="/workspace/venv-comfyui"
+if [ -d "${COMFYUI_VENV_PATH}" ] && [ ! -L "${COMFYUI_VENV_PATH}" ]; then
+    if [ ! -d "${COMFYUI_VENV_PERSIST}" ]; then
+        echo "--- First run detected for ComfyUI venv. Migrating to persistent storage... ---"
+        rsync -a "${COMFYUI_VENV_PATH}/" "${COMFYUI_VENV_PERSIST}/"
+    fi
+    rm -rf "${COMFYUI_VENV_PATH}"
+    ln -s "${COMFYUI_VENV_PERSIST}" "${COMFYUI_VENV_PATH}"
+fi
+
 # --- 1. Open WebUI Persistent Data Setup ---
 echo "--- Ensuring Open WebUI data is persistent in ${OPENWEBUI_DATA_DIR}... ---"
 if [ -d "/app/backend/data" ] && [ ! -L "/app/backend/data" ]; then

--- a/start_comfyui.sh
+++ b/start_comfyui.sh
@@ -8,7 +8,7 @@ CMD_ARGS=(
     "--listen" "0.0.0.0" \
     "--port" "8188" \
     "--preview-method" "auto" \
-    "--extra-model-paths-config" "/etc/comfyui_model_paths.yaml" \
+    "--extra-model-paths-config" "/opt/ComfyUI/extra_model_paths.yaml" \
     "--input-directory" "/opt/ComfyUI/input" \
     "--output-directory" "/opt/ComfyUI/output"
 )

--- a/start_textgenui.sh
+++ b/start_textgenui.sh
@@ -1,18 +1,16 @@
 #!/bin/bash
-# SCRIPT V6 - Added persistent upload directory and optional extension.
+# SCRIPT V8 - Link persistent user data and remove unsupported Gradio upload directory option
 
 cd /opt/text-generation-webui || exit
-
-# Create persistent upload directory
-UPLOAD_DIR="${TEXTGEN_DATA_DIR}/uploads"
-mkdir -p "$UPLOAD_DIR"
+# Link persistent user data for uploads and cache
+mkdir -p "${TEXTGEN_DATA_DIR}"
+ln -sfn "${TEXTGEN_DATA_DIR}" user_data
 
 # --- 1. Build Argument Array ---
 CMD_ARGS=()
 
 # --- 2. Networking and Base Flags ---
 CMD_ARGS+=(--listen --listen-host 0.0.0.0 --listen-port 7860 --api)
-CMD_ARGS+=(--gradio-upload-dir "$UPLOAD_DIR")
 
 # --- 3. Optional Extensions ---
 if [ -d "extensions/LLM_Web_search" ]; then


### PR DESCRIPTION
## Summary
- drop runpod helper library from final Docker image
- remove deprecated Gradio upload flag and link persistent user data for uploads
- persist ComfyUI virtual environment to workspace so custom node dependencies survive restarts
- pre-install `ultralytics` and `piexif` to avoid Impact Pack errors

## Testing
- `hadolint Dockerfile` *(fails: command not found; unable to locate package)*
- `docker build -q .` *(fails: cannot connect to Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68b050ad8a708322b422d79c04b175da