### PR TITLE
Install sam2 dependency and allow TextGenUI image uploads

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -109,8 +109,10 @@ RUN cd /opt/ComfyUI/custom_nodes && \
 
 # --- FIX: Pre-install dependencies for Impact Pack and other common nodes ---
 RUN --mount=type=cache,target=/root/.cache/pip \
-    /opt/venv-comfyui/bin/python3 -m pip install --no-cache-dir \
-    ultralytics piexif dill 'git+https://github.com/facebookresearch/segment-anything.git'
+    /opt/venv-comfyui/bin/python3 -m pip install --no-cache-dir --no-deps \
+    ultralytics piexif dill \
+    'git+https://github.com/facebookresearch/segment-anything.git' \
+    'git+https://github.com/facebookresearch/sam2'
 
 # --- 8. Remove VCS metadata to trim image ---
 RUN rm -rf /app/.git /opt/ComfyUI/.git /opt/text-generation-webui/.git

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -32,6 +32,19 @@ fi
 rm -rf "${COMFYUI_VENV_PATH}"
 ln -s "${COMFYUI_VENV_PERSIST}" "${COMFYUI_VENV_PATH}"
 
+# Ensure required ComfyUI node dependencies exist in the persistent venv
+COMFYUI_PIP="${COMFYUI_VENV_PATH}/bin/pip"
+COMFYUI_PY="${COMFYUI_VENV_PATH}/bin/python3"
+if ! "${COMFYUI_PY}" -c "import sam2" >/dev/null 2>&1; then
+    echo "--- Installing Impact Pack dependencies into ComfyUI venv ---"
+    if ! "${COMFYUI_PIP}" install --no-cache-dir --no-deps \
+        ultralytics piexif dill \
+        'git+https://github.com/facebookresearch/segment-anything.git' \
+        'git+https://github.com/facebookresearch/sam2'; then
+        echo "Warning: Failed to install optional Impact Pack dependencies" >&2
+    fi
+fi
+
 
 # --- 1. Open WebUI Persistent Data Setup ---
 echo "--- Ensuring Open WebUI data is persistent in ${OPENWEBUI_DATA_DIR}... ---"

--- a/start_textgenui.sh
+++ b/start_textgenui.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
-# SCRIPT V9 - Removed redundant symlinking to fix Gradio file upload errors.
+# SCRIPT V11 - Adds optional verbose logging via $DEBUG and optional file logging ($LOG_FILE).
+set -Eeuo pipefail
 
-cd /opt/text-generation-webui || exit
+cd /opt/text-generation-webui || exit 1
+
+# Allow Gradio to access cached uploads like image attachments
+export GRADIO_ALLOWED_PATH=/workspace/text-generation-webui
+# Clear any preset commandline arg environment variables that may inject unsupported flags
+unset COMMANDLINE_ARGS CLI_ARGS
 
 # --- 1. Build Argument Array ---
 CMD_ARGS=()
@@ -11,31 +17,44 @@ CMD_ARGS+=(--listen --listen-host 0.0.0.0 --listen-port 7860 --api)
 
 # --- 3. Optional Extensions ---
 if [ -d "extensions/LLM_Web_search" ]; then
-    CMD_ARGS+=(--extensions LLM_Web_search)
+  CMD_ARGS+=(--extensions LLM_Web_search)
 fi
 
 # --- 4. Model and LoRA Configuration ---
-CMD_ARGS+=(--lora-dir "${TEXTGEN_DATA_DIR}/loras")
+CMD_ARGS+=(--lora-dir "${TEXTGEN_DATA_DIR:-/workspace}/loras")
 
-if [ -n "$MODEL_NAME" ]; then
-    CMD_ARGS+=(--model "$MODEL_NAME")
+if [ -n "${MODEL_NAME:-}" ]; then
+  CMD_ARGS+=(--model "$MODEL_NAME")
 fi
 
-if [ -n "$LORA_NAMES" ]; then
-    IFS=',' read -ra loras <<< "$LORA_NAMES"
-    for lora in "${loras[@]}"; do
-        CMD_ARGS+=(--lora "$lora")
-    done
+if [ -n "${LORA_NAMES:-}" ]; then
+  IFS=',' read -ra loras <<< "$LORA_NAMES"
+  for lora in "${loras[@]}"; do
+    CMD_ARGS+=(--lora "$lora")
+  done
 fi
 
 # --- 5. Optional MoE config ---
-if [ -n "$NUM_EXPERTS_PER_TOKEN" ]; then
-    CMD_ARGS+=(--num-experts-per-token "$NUM_EXPERTS_PER_TOKEN")
+if [ -n "${NUM_EXPERTS_PER_TOKEN:-}" ]; then
+  CMD_ARGS+=(--num-experts-per-token "$NUM_EXPERTS_PER_TOKEN")
+fi
+
+# --- 6. Verbose toggle (ON by default) ---
+if [ "${DEBUG:-1}" = "1" ]; then
+  CMD_ARGS+=(--verbose)
 fi
 
 echo "--- Starting Text-Generation-WebUI with arguments: ---"
 printf " %q" "${CMD_ARGS[@]}"
 echo -e "\n----------------------------------------------------"
 
-# --- 6. Launch Server ---
-exec /opt/venv-textgen/bin/python3 server.py "${CMD_ARGS[@]}"
+# --- 7. Launch Server (optional file logging) ---
+if [ -n "${LOG_FILE:-}" ]; then
+  if command -v stdbuf >/dev/null 2>&1; then
+    stdbuf -oL -eL /opt/venv-textgen/bin/python3 server.py "${CMD_ARGS[@]}" 2>&1 | tee -a "$LOG_FILE"
+  else
+    /opt/venv-textgen/bin/python3 server.py "${CMD_ARGS[@]}" 2>&1 | tee -a "$LOG_FILE"
+  fi
+else
+  exec /opt/venv-textgen/bin/python3 server.py "${CMD_ARGS[@]}"
+fi


### PR DESCRIPTION
## Summary
- preinstall facebookresearch/sam2 so Impact Pack SAM2 nodes work out-of-the-box
- permit image attachments in text-generation-webui by whitelisting its cache directory via GRADIO_ALLOWED_PATH
- add DEBUG and LOG_FILE options to start_textgenui.sh for easier troubleshooting
- drop unsupported flags for TextGenUI startup
- auto-install Impact Pack dependencies in the persistent ComfyUI venv if missing
- avoid reinstalling heavy CUDA stacks by installing Impact Pack deps without pulling extra dependencies and warning instead of failing

## Testing
- `bash -n Dockerfile`
- `bash -n entrypoint.sh`
- `bash -n start_textgenui.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b08a98f358832294fd7ee9a0146bcc