### PR TITLE
Reduce ComfyUI dependency footprint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -107,12 +107,12 @@ RUN cd /opt/ComfyUI/custom_nodes && \
     cd ComfyUI-Manager && \
     /opt/venv-comfyui/bin/python3 -m pip install --no-cache-dir -r requirements.txt
 
-# --- FIX: Pre-install dependencies for Impact Pack and other common nodes ---
+# --- Pre-install dependencies for Impact Pack and other common nodes using existing CUDA torch ---
 RUN --mount=type=cache,target=/root/.cache/pip \
-    /opt/venv-comfyui/bin/python3 -m pip install --no-cache-dir \
-    ultralytics piexif dill \
-    'git+https://github.com/facebookresearch/segment-anything.git' \
-    'git+https://github.com/facebookresearch/sam2'
+    /opt/venv-comfyui/bin/python3 -m pip install --no-cache-dir --no-build-isolation \
+        ultralytics piexif dill \
+        'git+https://github.com/facebookresearch/segment-anything.git' \
+        'git+https://github.com/facebookresearch/sam2'
 
 # --- 8. Remove VCS metadata to trim image ---
 RUN rm -rf /app/.git /opt/ComfyUI/.git /opt/text-generation-webui/.git

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -36,7 +36,7 @@ ln -s "${COMFYUI_VENV_PERSIST}" "${COMFYUI_VENV_PATH}"
 COMFYUI_PIP="${COMFYUI_VENV_PATH}/bin/pip"
 if ! "${COMFYUI_PIP}" show sam2 > /dev/null 2>&1; then
     echo "--- Installing Impact Pack dependencies into ComfyUI venv ---"
-    "${COMFYUI_PIP}" install --no-cache-dir \
+    "${COMFYUI_PIP}" install --no-cache-dir --no-build-isolation \
         ultralytics piexif dill \
         'git+https://github.com/facebookresearch/segment-anything.git' \
         'git+https://github.com/facebookresearch/sam2'


### PR DESCRIPTION
## Summary
- Install Impact Pack dependencies using the prebuilt CUDA-enabled torch
- Avoid CPU-only torch reinstall by disabling build isolation for Impact Pack packages

## Testing
- `bash -n entrypoint.sh`
- `shellcheck entrypoint.sh`
- `hadolint Dockerfile`

------
https://chatgpt.com/codex/tasks/task_e_68b1b4b94e308322a40126a27695fab9